### PR TITLE
Improve portfolio README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,64 @@
-<h1 align="left">I'm Wissam Almsalati</h1>
+# Wissam Almsalati
 
-- 👨‍💻 Software Engineering Student | 💻 Full Stack Developer
+**Software Engineering Student | Full Stack Developer**
 
-- 🌟 Crafting delightful mobile experiences with Flutter while honing my skills as a software engineering student.
+🌟 Crafting delightful mobile experiences with Flutter while honing my skills as a software engineering student.
 
-- 🔍 Passionate about learning and exploring new technologies, and always striving to keep up with the latest trends in mobile development.
+🔍 Passionate about learning and exploring new technologies and always striving to keep up with the latest trends in mobile development.
 
-- 🌱 I’m currently learning **Next Js**
+🌱 I’m currently learning **Next.js**
 
-- 📫 How to reach me : email **wissamalmsalati@gmail.com**
+📫 How to reach me: **wissamalmsalati@gmail.com**
 
-<h3 align="left">Languages and Tools:</h3>
+## Languages and Tools
 <p align="left">
   <a href="https://www.cprogramming.com/" target="_blank" rel="noreferrer">
-    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/c/c-original.svg" alt="c" width="40" height="40"/>
+    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/c/c-original.svg" alt="C" width="40" height="40" />
   </a>
   <a href="https://www.w3schools.com/css/" target="_blank" rel="noreferrer">
-    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg" alt="css3" width="40" height="40"/>
+    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg" alt="CSS3" width="40" height="40" />
   </a>
   <a href="https://dart.dev" target="_blank" rel="noreferrer">
-    <img src="https://www.vectorlogo.zone/logos/dartlang/dartlang-icon.svg" alt="dart" width="40" height="40"/>
+    <img src="https://www.vectorlogo.zone/logos/dartlang/dartlang-icon.svg" alt="Dart" width="40" height="40" />
   </a>
   <a href="https://firebase.google.com/" target="_blank" rel="noreferrer">
-    <img src="https://www.vectorlogo.zone/logos/firebase/firebase-icon.svg" alt="firebase" width="40" height="40"/>
+    <img src="https://www.vectorlogo.zone/logos/firebase/firebase-icon.svg" alt="Firebase" width="40" height="40" />
   </a>
   <a href="https://flutter.dev" target="_blank" rel="noreferrer">
-    <img src="https://www.vectorlogo.zone/logos/flutterio/flutterio-icon.svg" alt="flutter" width="40" height="40"/>
+    <img src="https://www.vectorlogo.zone/logos/flutterio/flutterio-icon.svg" alt="Flutter" width="40" height="40" />
   </a>
   <a href="https://git-scm.com/" target="_blank" rel="noreferrer">
-    <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="git" width="40" height="40"/>
+    <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="Git" width="40" height="40" />
   </a>
   <a href="https://www.w3.org/html/" target="_blank" rel="noreferrer">
-    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original-wordmark.svg" alt="html5" width="40" height="40"/>
+    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original-wordmark.svg" alt="HTML5" width="40" height="40" />
   </a>
   <a href="https://www.java.com" target="_blank" rel="noreferrer">
-    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/java/java-original.svg" alt="java" width="40" height="40"/>
+    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/java/java-original.svg" alt="Java" width="40" height="40" />
   </a>
   <a href="https://www.mongodb.com/" target="_blank" rel="noreferrer">
-    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mongodb/mongodb-original-wordmark.svg" alt="mongodb" width="40" height="40"/>
+    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mongodb/mongodb-original-wordmark.svg" alt="MongoDB" width="40" height="40" />
   </a>
   <a href="https://www.mysql.com/" target="_blank" rel="noreferrer">
-    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mysql/mysql-original-wordmark.svg" alt="mysql" width="40" height="40"/>
+    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mysql/mysql-original-wordmark.svg" alt="MySQL" width="40" height="40" />
   </a>
   <a href="https://reactjs.org/" target="_blank" rel="noreferrer">
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="react" width="40" height="40"/>
-</a>
-<a href="https://nextjs.org/" target="_blank" rel="noreferrer">
-  <img src="https://cdn.worldvectorlogo.com/logos/nextjs-2.svg" alt="nextjs" width="40" height="40"/>
-</a>
-
+    <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="React" width="40" height="40" />
+  </a>
+  <a href="https://nextjs.org/" target="_blank" rel="noreferrer">
+    <img src="https://cdn.worldvectorlogo.com/logos/nextjs-2.svg" alt="Next.js" width="40" height="40" />
+  </a>
 </p>
 
+## GitHub Stats
 <p>
-  <img align="left" src="https://github-readme-stats.vercel.app/api/top-langs?username=wissamalmsalati&show_icons=true&theme=dracula&locale=en&layout=compact" alt="wissamalmsalati" />
+  <img align="left" src="https://github-readme-stats.vercel.app/api/top-langs?username=wissamalmsalati&show_icons=true&theme=dracula&locale=en&layout=compact" alt="Wissam's Top Languages" />
 </p>
 
 <p>&nbsp;
-  <img align="center" src="https://github-readme-stats.vercel.app/api?username=wissamalmsalati&show_icons=true&theme=dracula&locale=en" alt="wissamalmsalati" />
+  <img align="center" src="https://github-readme-stats.vercel.app/api?username=wissamalmsalati&show_icons=true&theme=dracula&locale=en" alt="Wissam's GitHub Stats" />
 </p>
 
 <p>
-  <img align="center" src="https://github-readme-streak-stats.herokuapp.com/?user=wissamalmsalati&theme=dracula" alt="wissamalmsalati" />
+  <img align="center" src="https://github-readme-streak-stats.herokuapp.com/?user=wissamalmsalati&theme=dracula" alt="Wissam's GitHub Streak" />
 </p>


### PR DESCRIPTION
## Summary
- rewrite README using standard Markdown
- fix typographical issues and update Next.js spelling
- keep icons and GitHub stats but improve formatting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871519b0644832e825104f489ba0758